### PR TITLE
修复龙王合剂附魔显示问题&怪物放置器的怪物补充及水晶宝箱怪修复

### DIFF
--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/blobs/MagicFire.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/blobs/MagicFire.java
@@ -31,11 +31,11 @@ public class MagicFire extends Blob {
             for(Item item : Dungeon.level.heaps.get(pos).items){
                 if(item instanceof Armor){
                     ((Armor) item).inscribe(Armor.Glyph.random());
-                }
-                if(item instanceof Weapon){
+                    GLog.p(Messages.get(MagicFire.class, "good")+item.name()+"\n");
+                }else if(item instanceof Weapon){
                     ((Weapon) item).enchant(Weapon.Enchantment.random());
+                    GLog.p(Messages.get(MagicFire.class, "good")+item.name()+"\n");
                 }
-                GLog.p(Messages.get(MagicFire.class, "good")+item.name()+"\n");
             }
         }
     }

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/CrystalMimic.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/CrystalMimic.java
@@ -27,6 +27,7 @@ import com.shatteredpixel.shatteredpixeldungeon.actors.Actor;
 import com.shatteredpixel.shatteredpixeldungeon.actors.Char;
 import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Buff;
 import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Haste;
+import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Levitation;
 import com.shatteredpixel.shatteredpixeldungeon.actors.hero.Hero;
 import com.shatteredpixel.shatteredpixeldungeon.effects.CellEmitter;
 import com.shatteredpixel.shatteredpixeldungeon.effects.Speck;
@@ -104,6 +105,7 @@ public class CrystalMimic extends Mimic {
 	public void stopHiding(){
 		state = FLEEING;
 		if (sprite != null) sprite.idle();
+		Buff.affect(this, Levitation.class, Levitation.DURATION/2f);
 		//haste for 2 turns if attacking
 		if (alignment == Alignment.NEUTRAL){
 			Buff.affect(this, Haste.class, 2f);

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/custom/dict/DictSpriteSheet.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/custom/dict/DictSpriteSheet.java
@@ -239,6 +239,10 @@ public class DictSpriteSheet {
                 return new GreenSltingSprite();
             case BEE:
                 return new Image(Assets.Sprites.BEE, 0, 0, 16, 16);
+            case TORMENTED_SPIRIT:
+                return new Image(Assets.Sprites.WRAITH, 0, 16, 14, 16);
+            case PHANTOM_PIRANHA:
+                return new Image(Assets.Sprites.PIRANHA, 0, 16, 12, 16);
 
             case SAD_GHOST:
                 return new Image(Assets.Sprites.GHOST, 0, 0, 14, 15);
@@ -388,7 +392,8 @@ public class DictSpriteSheet {
 
     public static final int GLTX = 906 + 10000;
     public static final int BEE             = 707 + 10000;
-
+    public static final int TORMENTED_SPIRIT = 708 + 10000;
+    public static final int PHANTOM_PIRANHA = 709 + 10000;
     public static final int SAD_GHOST       = 800 + 10000;
     public static final int WAND_MAKER      = 801 + 10000;
     public static final int BLACKSMITH      = 802 + 10000;

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/custom/testmode/MobPlacer.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/custom/testmode/MobPlacer.java
@@ -1,5 +1,6 @@
 package com.shatteredpixel.shatteredpixeldungeon.custom.testmode;
 
+import com.shatteredpixel.shatteredpixeldungeon.Assets;
 import com.shatteredpixel.shatteredpixeldungeon.Dungeon;
 import com.shatteredpixel.shatteredpixeldungeon.ShatteredPixelDungeon;
 import com.shatteredpixel.shatteredpixeldungeon.actors.Actor;
@@ -48,6 +49,7 @@ import com.shatteredpixel.shatteredpixeldungeon.actors.mobs.NewBlackHost;
 import com.shatteredpixel.shatteredpixeldungeon.actors.mobs.OGPDLLS;
 import com.shatteredpixel.shatteredpixeldungeon.actors.mobs.OGPDNQHZ;
 import com.shatteredpixel.shatteredpixeldungeon.actors.mobs.OGPDZSLS;
+import com.shatteredpixel.shatteredpixeldungeon.actors.mobs.PhantomPiranha;
 import com.shatteredpixel.shatteredpixeldungeon.actors.mobs.Piranha;
 import com.shatteredpixel.shatteredpixeldungeon.actors.mobs.Rat;
 import com.shatteredpixel.shatteredpixeldungeon.actors.mobs.RedMurderer;
@@ -72,6 +74,7 @@ import com.shatteredpixel.shatteredpixeldungeon.actors.mobs.Statue;
 import com.shatteredpixel.shatteredpixeldungeon.actors.mobs.Succubus;
 import com.shatteredpixel.shatteredpixeldungeon.actors.mobs.Swarm;
 import com.shatteredpixel.shatteredpixeldungeon.actors.mobs.Thief;
+import com.shatteredpixel.shatteredpixeldungeon.actors.mobs.TormentedSpirit;
 import com.shatteredpixel.shatteredpixeldungeon.actors.mobs.Warlock;
 import com.shatteredpixel.shatteredpixeldungeon.actors.mobs.Wraith;
 import com.shatteredpixel.shatteredpixeldungeon.actors.mobs.XTG200;
@@ -508,7 +511,11 @@ public class MobPlacer extends TestItem{
         STATUE(Statue.class, DictSpriteSheet.STATUE),
         ARMORED_STATUE(ArmoredStatue.class, DictSpriteSheet.ARMORED_STATUE),
         WRAITH(Wraith.class, DictSpriteSheet.WRAITH),
+        TORMENTED_SPIRIT(TormentedSpirit.class,DictSpriteSheet.TORMENTED_SPIRIT),
+        PHANTOM_PIRANHA(PhantomPiranha.class,DictSpriteSheet.PHANTOM_PIRANHA),
         PIRANHA(Piranha.class, DictSpriteSheet.FISH),
+
+
 
         ZSLS(OGPDZSLS.class, DictSpriteSheet.OGPDZSLS),
         LLS(OGPDLLS.class, DictSpriteSheet.OGPDLLS),


### PR DESCRIPTION
1.修复了龙王合剂的一个附魔显示问题：该问题曾导致龙王合剂范围内的所有物品（包含不可附魔物品）都将显示“附魔文本”
2.修复了水晶宝箱怪不会飞的问题
3.怪物放置器补充幻影食人鱼及咒缚灵